### PR TITLE
Fixes for Vrui-4 enabling HTC Vive

### DIFF
--- a/Contours.h
+++ b/Contours.h
@@ -15,7 +15,6 @@
 /* Vrui includes */
 #include <GL/GLColorMap.h>
 #include <GLMotif/Blind.h>
-#include <GLMotif/Popup.h>
 #include <GLMotif/PopupWindow.h>
 #include <GLMotif/RadioBox.h>
 #include <GLMotif/RowColumn.h>

--- a/ExampleVTKReader.cpp
+++ b/ExampleVTKReader.cpp
@@ -508,6 +508,9 @@ void ExampleVTKReader::initContext(GLContextData& contextData) const
 //----------------------------------------------------------------------------
 void ExampleVTKReader::display(GLContextData& contextData) const
 {
+  // Save OpenGL state
+  glPushAttrib(GL_ENABLE_BIT|GL_POLYGON_BIT);
+
   int numberOfSupportedClippingPlanes;
   glGetIntegerv(GL_MAX_CLIP_PLANES, &numberOfSupportedClippingPlanes);
   int clippingPlaneIndex = 0;
@@ -542,6 +545,9 @@ void ExampleVTKReader::display(GLContextData& contextData) const
       ++clippingPlaneIndex;
       }
     }
+
+    // Restore OpenGL state
+    glPopAttrib();
 }
 
 //----------------------------------------------------------------------------

--- a/ExampleVTKReader.cpp
+++ b/ExampleVTKReader.cpp
@@ -15,7 +15,6 @@
 #include <GL/gl.h>
 #include <GLMotif/CascadeButton.h>
 #include <GLMotif/Label.h>
-#include <GLMotif/Popup.h>
 #include <GLMotif/PopupMenu.h>
 #include <GLMotif/RadioBox.h>
 #include <GLMotif/ToggleButton.h>
@@ -283,14 +282,12 @@ GLMotif::PopupMenu* ExampleVTKReader::createRepresentationMenu(void)
 }
 
 //----------------------------------------------------------------------------
-GLMotif::Popup * ExampleVTKReader::createAnalysisToolsMenu(void)
+GLMotif::PopupMenu * ExampleVTKReader::createAnalysisToolsMenu(void)
 {
   const GLMotif::StyleSheet* ss = Vrui::getWidgetManager()->getStyleSheet();
 
-  GLMotif::Popup * analysisToolsMenuPopup = new GLMotif::Popup(
+  GLMotif::PopupMenu * analysisToolsMenu = new GLMotif::PopupMenu(
     "analysisToolsMenuPopup", Vrui::getWidgetManager());
-  GLMotif::SubMenu* analysisToolsMenu = new GLMotif::SubMenu(
-    "representationMenu", analysisToolsMenuPopup, false);
 
   GLMotif::RadioBox * analysisTools_RadioBox = new GLMotif::RadioBox(
     "analysisTools", analysisToolsMenu, true);
@@ -307,19 +304,17 @@ GLMotif::Popup * ExampleVTKReader::createAnalysisToolsMenu(void)
   analysisTools_RadioBox->setSelectionMode(GLMotif::RadioBox::ALWAYS_ONE);
   analysisTools_RadioBox->setSelectedToggle(showClippingPlane);
 
-  analysisToolsMenu->manageChild();
-  return analysisToolsMenuPopup;
+  analysisToolsMenu->manageMenu();
+  return analysisToolsMenu;
 }
 
 //----------------------------------------------------------------------------
-GLMotif::Popup * ExampleVTKReader::createWidgetsMenu(void)
+GLMotif::PopupMenu * ExampleVTKReader::createWidgetsMenu(void)
 {
   const GLMotif::StyleSheet* ss = Vrui::getWidgetManager()->getStyleSheet();
 
-  GLMotif::Popup * widgetsMenuPopup = new GLMotif::Popup(
+  GLMotif::PopupMenu * widgetsMenu = new GLMotif::PopupMenu(
     "widgetsMenuPopup", Vrui::getWidgetManager());
-  GLMotif::SubMenu* widgetsMenu = new GLMotif::SubMenu(
-    "widgetsMenu", widgetsMenuPopup, false);
 
   GLMotif::ToggleButton * showSlicesDialog = new GLMotif::ToggleButton(
     "ShowSlicesDialog", widgetsMenu, "Slices");
@@ -340,17 +335,17 @@ GLMotif::Popup * ExampleVTKReader::createWidgetsMenu(void)
   showContoursDialog->getValueChangedCallbacks().add(this,
     &ExampleVTKReader::showContoursDialogCallback);
 
-  widgetsMenu->manageChild();
-  return widgetsMenuPopup;
+  widgetsMenu->manageMenu();
+  return widgetsMenu;
 }
 
 //----------------------------------------------------------------------------
-GLMotif::Popup* ExampleVTKReader::createColorMapSubMenu(void)
+GLMotif::PopupMenu* ExampleVTKReader::createColorMapSubMenu(void)
 {
-  GLMotif::Popup * colorMapSubMenuPopup = new GLMotif::Popup(
+  GLMotif::PopupMenu * colorMapSubMenu = new GLMotif::PopupMenu(
     "ColorMapSubMenuPopup", Vrui::getWidgetManager());
   GLMotif::RadioBox* colorMaps = new GLMotif::RadioBox(
-    "ColorMaps", colorMapSubMenuPopup, false);
+    "ColorMaps", colorMapSubMenu, false);
   colorMaps->setSelectionMode(GLMotif::RadioBox::ALWAYS_ONE);
   colorMaps->addToggle("Full Rainbow");
   colorMaps->addToggle("Inverse Full Rainbow");
@@ -370,16 +365,16 @@ GLMotif::Popup* ExampleVTKReader::createColorMapSubMenu(void)
   colorMaps->getValueChangedCallbacks().add(this,
     &ExampleVTKReader::changeColorMapCallback);
   colorMaps->manageChild();
-  return colorMapSubMenuPopup;
+  return colorMapSubMenu;
 } // end createColorMapSubMenu()
 
 //----------------------------------------------------------------------------
-GLMotif::Popup*  ExampleVTKReader::createAlphaSubMenu(void)
+GLMotif::PopupMenu*  ExampleVTKReader::createAlphaSubMenu(void)
 {
-  GLMotif::Popup * alphaSubMenuPopup = new GLMotif::Popup(
+  GLMotif::PopupMenu * alphaSubMenu = new GLMotif::PopupMenu(
     "AlphaSubMenuPopup", Vrui::getWidgetManager());
   GLMotif::RadioBox* alphas = new GLMotif::RadioBox(
-    "Alphas", alphaSubMenuPopup, false);
+    "Alphas", alphaSubMenu, false);
   alphas->setSelectionMode(GLMotif::RadioBox::ALWAYS_ONE);
   alphas->addToggle("Up");
   alphas->addToggle("Down");
@@ -388,7 +383,7 @@ GLMotif::Popup*  ExampleVTKReader::createAlphaSubMenu(void)
   alphas->setSelectedToggle(0);
   alphas->getValueChangedCallbacks().add(this, &ExampleVTKReader::changeAlphaCallback);
   alphas->manageChild();
-  return alphaSubMenuPopup;
+  return alphaSubMenu;
 } // end createAlphaSubMenu()
 
 //----------------------------------------------------------------------------

--- a/ExampleVTKReader.cpp
+++ b/ExampleVTKReader.cpp
@@ -15,7 +15,6 @@
 #include <GL/gl.h>
 #include <GLMotif/CascadeButton.h>
 #include <GLMotif/Label.h>
-#include <GLMotif/Menu.h>
 #include <GLMotif/Popup.h>
 #include <GLMotif/PopupMenu.h>
 #include <GLMotif/RadioBox.h>
@@ -173,11 +172,9 @@ void ExampleVTKReader::setProgressVisibility(bool vis)
 //----------------------------------------------------------------------------
 GLMotif::PopupMenu* ExampleVTKReader::createMainMenu(void)
 {
-  GLMotif::PopupMenu* mainMenuPopup = new GLMotif::PopupMenu(
+  GLMotif::PopupMenu* mainMenu = new GLMotif::PopupMenu(
     "MainMenuPopup",Vrui::getWidgetManager());
-  mainMenuPopup->setTitle("Main Menu");
-  GLMotif::Menu* mainMenu = new GLMotif::Menu(
-    "MainMenu",mainMenuPopup,false);
+  mainMenu->setTitle("Main Menu");
 
   const GLMotif::StyleSheet& styleSheet = *Vrui::getWidgetManager()->getStyleSheet();
 
@@ -229,19 +226,17 @@ GLMotif::PopupMenu* ExampleVTKReader::createMainMenu(void)
   showRenderingDialog->getValueChangedCallbacks().add(
     this, &ExampleVTKReader::showRenderingDialogCallback);
 
-  mainMenu->manageChild();
-  return mainMenuPopup;
+  mainMenu->manageMenu();
+  return mainMenu;
 }
 
 //----------------------------------------------------------------------------
-GLMotif::Popup* ExampleVTKReader::createRepresentationMenu(void)
+GLMotif::PopupMenu* ExampleVTKReader::createRepresentationMenu(void)
 {
   const GLMotif::StyleSheet* ss = Vrui::getWidgetManager()->getStyleSheet();
 
-  GLMotif::Popup* representationMenuPopup = new GLMotif::Popup(
+  GLMotif::PopupMenu* representationMenu = new GLMotif::PopupMenu(
     "representationMenuPopup", Vrui::getWidgetManager());
-  GLMotif::SubMenu* representationMenu = new GLMotif::SubMenu(
-    "representationMenu", representationMenuPopup, false);
 
   GLMotif::ToggleButton* showOutline=new GLMotif::ToggleButton(
     "ShowOutline",representationMenu,"Outline");
@@ -283,8 +278,8 @@ GLMotif::Popup* ExampleVTKReader::createRepresentationMenu(void)
   representation_RadioBox->setSelectionMode(GLMotif::RadioBox::ATMOST_ONE);
   representation_RadioBox->setSelectedToggle(showSurface);
 
-  representationMenu->manageChild();
-  return representationMenuPopup;
+  representationMenu->manageMenu();
+  return representationMenu;
 }
 
 //----------------------------------------------------------------------------

--- a/ExampleVTKReader.h
+++ b/ExampleVTKReader.h
@@ -24,7 +24,6 @@
 /* Forward Declarations */
 namespace GLMotif
 {
-  class Popup;
   class PopupMenu;
 }
 
@@ -50,10 +49,10 @@ private:
   GLMotif::PopupMenu* mainMenu; // The program's main menu
   GLMotif::PopupMenu* createMainMenu(void);
   GLMotif::PopupMenu* createRepresentationMenu(void);
-  GLMotif::Popup* createAnalysisToolsMenu(void);
-  GLMotif::Popup* createWidgetsMenu(void);
-  GLMotif::Popup*  createColorMapSubMenu(void);
-  GLMotif::Popup*  createAlphaSubMenu(void);
+  GLMotif::PopupMenu* createAnalysisToolsMenu(void);
+  GLMotif::PopupMenu* createWidgetsMenu(void);
+  GLMotif::PopupMenu*  createColorMapSubMenu(void);
+  GLMotif::PopupMenu*  createAlphaSubMenu(void);
   GLMotif::PopupWindow* renderingDialog;
   GLMotif::PopupWindow* createRenderingDialog(void);
   GLMotif::TextField* opacityValue;

--- a/ExampleVTKReader.h
+++ b/ExampleVTKReader.h
@@ -49,7 +49,7 @@ private:
   /* Elements: */
   GLMotif::PopupMenu* mainMenu; // The program's main menu
   GLMotif::PopupMenu* createMainMenu(void);
-  GLMotif::Popup* createRepresentationMenu(void);
+  GLMotif::PopupMenu* createRepresentationMenu(void);
   GLMotif::Popup* createAnalysisToolsMenu(void);
   GLMotif::Popup* createWidgetsMenu(void);
   GLMotif::Popup*  createColorMapSubMenu(void);

--- a/Isosurfaces.cpp
+++ b/Isosurfaces.cpp
@@ -263,10 +263,10 @@ void Isosurfaces::createColorSliders(const GLMotif::StyleSheet& styleSheet, GLMo
 /*
  * createIsosurfaceColorMapSubMenu - Creates a submenu of the available isosurface color maps.
  *
- * return - GLMotif::Popup *
+ * return - GLMotif::PopupMenu *
  */
-GLMotif::Popup * Isosurfaces::createIsosurfaceColorMapSubMenu(void) {
-    GLMotif::Popup * isosurfaceColorMapSubMenuPopup = new GLMotif::Popup("IsosurfaceColorMapSubMenuPopup", Vrui::getWidgetManager());
+GLMotif::PopupMenu * Isosurfaces::createIsosurfaceColorMapSubMenu(void) {
+    GLMotif::PopupMenu * isosurfaceColorMapSubMenuPopup = new GLMotif::PopupMenu("IsosurfaceColorMapSubMenuPopup", Vrui::getWidgetManager());
     GLMotif::RadioBox * isosurfaceColorMaps = new GLMotif::RadioBox("IsosurfaceColorMaps", isosurfaceColorMapSubMenuPopup, false);
     isosurfaceColorMaps->setSelectionMode(GLMotif::RadioBox::ALWAYS_ONE);
     isosurfaceColorMaps->addToggle("Full Rainbow");

--- a/Isosurfaces.h
+++ b/Isosurfaces.h
@@ -4,7 +4,7 @@
 /* Vrui includes */
 #include <GL/GLColorMap.h>
 #include <GLMotif/Blind.h>
-#include <GLMotif/Popup.h>
+#include <GLMotif/PopupMenu.h>
 #include <GLMotif/PopupWindow.h>
 #include <GLMotif/RadioBox.h>
 #include <GLMotif/RowColumn.h>
@@ -63,7 +63,7 @@ private:
     GLMotif::RowColumn * createColorSliderBox(const GLMotif::StyleSheet & styleSheet, GLMotif::RowColumn * colorEditor);
     void createColorSliders(const GLMotif::StyleSheet & styleSheet, GLMotif::RowColumn * colorEditor);
     void createColorSwatchesWidget(const GLMotif::StyleSheet & styleSheet, GLMotif::RowColumn * & colorEditor);
-    GLMotif::Popup * createIsosurfaceColorMapSubMenu(void);
+    GLMotif::PopupMenu * createIsosurfaceColorMapSubMenu(void);
     void createAIsosurfaces(GLMotif::RowColumn * & abcIsosurfacesRowColumn, const GLMotif::StyleSheet & styleSheet);
     void createABCIsosurfaces(const GLMotif::StyleSheet & styleSheet, GLMotif::RowColumn * & colorMapDialog);
     void createBIsosurfaces(GLMotif::RowColumn * & abcIsosurfacesRowColumn, const GLMotif::StyleSheet & styleSheet);

--- a/Slices.cpp
+++ b/Slices.cpp
@@ -263,10 +263,10 @@ void Slices::createColorSliders(const GLMotif::StyleSheet& styleSheet, GLMotif::
 /*
  * createSliceColorMapSubMenu - Creates a submenu of the available slice color maps.
  *
- * return - GLMotif::Popup *
+ * return - GLMotif::PopupMenu *
  */
-GLMotif::Popup * Slices::createSliceColorMapSubMenu(void) {
-    GLMotif::Popup * sliceColorMapSubMenuPopup = new GLMotif::Popup("SliceColorMapSubMenuPopup", Vrui::getWidgetManager());
+GLMotif::PopupMenu * Slices::createSliceColorMapSubMenu(void) {
+    GLMotif::PopupMenu * sliceColorMapSubMenuPopup = new GLMotif::PopupMenu("SliceColorMapSubMenuPopup", Vrui::getWidgetManager());
     GLMotif::RadioBox * sliceColorMaps = new GLMotif::RadioBox("SliceColorMaps", sliceColorMapSubMenuPopup, false);
     sliceColorMaps->setSelectionMode(GLMotif::RadioBox::ALWAYS_ONE);
     sliceColorMaps->addToggle("Full Rainbow");

--- a/Slices.h
+++ b/Slices.h
@@ -4,7 +4,7 @@
 /* Vrui includes */
 #include <GL/GLColorMap.h>
 #include <GLMotif/Blind.h>
-#include <GLMotif/Popup.h>
+#include <GLMotif/PopupMenu.h>
 #include <GLMotif/PopupWindow.h>
 #include <GLMotif/RadioBox.h>
 #include <GLMotif/RowColumn.h>
@@ -63,7 +63,7 @@ private:
     GLMotif::RowColumn * createColorSliderBox(const GLMotif::StyleSheet & styleSheet, GLMotif::RowColumn * colorEditor);
     void createColorSliders(const GLMotif::StyleSheet & styleSheet, GLMotif::RowColumn * colorEditor);
     void createColorSwatchesWidget(const GLMotif::StyleSheet & styleSheet, GLMotif::RowColumn * & colorEditor);
-    GLMotif::Popup * createSliceColorMapSubMenu(void);
+    GLMotif::PopupMenu * createSliceColorMapSubMenu(void);
     void createXSlices(GLMotif::RowColumn * & xyzSlicesRowColumn, const GLMotif::StyleSheet & styleSheet);
     void createXYZSlices(const GLMotif::StyleSheet & styleSheet, GLMotif::RowColumn * & colorMapDialog);
     void createYSlices(GLMotif::RowColumn * & xyzSlicesRowColumn, const GLMotif::StyleSheet & styleSheet);


### PR DESCRIPTION
- Fixed menus
- Fixed Vive rendering

Related: https://github.com/VruiVTK/vtkVRUI-superbuild/pull/2

In principal the VolumeViewer works but volume rendering looks a little bit odd:

It looks like the view direction is not passed to the volume rendering shader. So seen from the top it looks good but when diving in to the dataset one can see that the rendering happens on a surface which is always pointing upwards and not adapting to the viewing direction. It is hard to describe.. Also the volume rendering disappears completely when viewing from specific angles..